### PR TITLE
Install dh-virtualenv 1.2 from debian testing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,12 @@ COPY entrypoint.sh /entrypoint.sh
 
 # Installs the `dpkg-buildpackage` command
 RUN apt-get update
-RUN apt-get install build-essential debhelper devscripts -y
+RUN apt-get install build-essential debhelper devscripts perl python3 python3-virtualenv -y
+
+# Install `dh-virtualenv` 1.2
+RUN deb http://http.us.debian.org/debian bullseye main
+RUN apt-get download dh-virtualenv
+RUN dpkg -i -f --ignore-depends=perl,python3,virtualenv,sphinx-rtd-theme-common dh-virtualenv.deb
 
 # Code file to execute when the docker container starts up (`entrypoint.sh`)
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
Per https://github.com/nylas/cloud-core/pull/1714 we want to run dh-virtualenv 1.2, so that we can set the version of pip used. Version 1.2 is currently only available on debian testing, so we're going to force install it in out docker container and manage the dependencies ourselves.